### PR TITLE
Introduce initial maven support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files
 *.jar
 *.war
 *.ear
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Eclipse artifacts
+.classpath
+.project

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # MultiLab
-An Affordance Architecture for Agent-Based Models of Endogenous Innovation
+An Affordance Architecture for Agent-Based Models of Endogenous Innovation.
+
+## Run requirements
+====
+- Oracle JRE or OpenJDK JRE
+
+## Build requirements
+====
+- Oracle or OpenJDK
+
+## Building
+====
+
+
+## Running
+====

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MultiLab
-An Affordance Architecture for Agent-Based Models of Endogenous Innovation.
+__An Affordance Architecture for Agent-Based Models of Endogenous Innovation.__
 
 ## Run requirements
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>MultiLab</name>
+  <url>https://github.com/russellcameronthomas/MultiLab</url>
+  <groupId>edu.gmu</groupId>
+  <artifactId>multilab</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <dependencies>
+  <dependency>
+  	<groupId>org.apache-extras.beanshell</groupId>
+  	<artifactId>bsh</artifactId>
+  	<version>2.0b5</version>
+  </dependency>
+  <dependency>
+  	<groupId>com.lowagie</groupId>
+  	<artifactId>itext</artifactId>
+  	<version>4.2.1</version>
+  </dependency>
+  <dependency>
+  	<groupId>org.jfree</groupId>
+  	<artifactId>jcommon</artifactId>
+  	<version>1.0.23</version>
+  </dependency>
+  <dependency>
+  	<groupId>org.jfree</groupId>
+  	<artifactId>jfreechart</artifactId>
+  	<version>1.0.19</version>
+  </dependency>
+  <dependency>
+  	<groupId>javax.media</groupId>
+  	<artifactId>jmf</artifactId>
+  	<version>2.1.1e</version>
+  </dependency>
+  <dependency>
+  	<groupId>edu.gmu.cs</groupId>
+  	<artifactId>mason</artifactId>
+  	<version>14.0</version>
+  </dependency>
+  <dependency>
+  	<groupId>org.semispace</groupId>
+  	<artifactId>semispace-main</artifactId>
+  	<version>1.3.1</version>
+  </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
I've introduced a stubbed readme, an initial pom.xml for maven support, and a blank travis.yml file. The readme stub contains some sections we can fill in to instruct developers and users how to build and run the project. The initial pom contains most of the dependencies needed to build the project and local development environments, but MASON is not being actively maintained in Maven Central, which causes build errors. The travis.yml file can be populated to automatically run tests and builds for the project.