### PR TITLE
Provide initial maven support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # MultiLab
-An Affordance Architecture for Agent-Based Models of Endogenous Innovation
+An Affordance Architecture for Agent-Based Models of Endogenous Innovation.
+
+## Run requirements
+====
+- Oracle JRE or OpenJDK JRE
+
+## Build requirements
+====
+- Oracle or OpenJDK
+
+## Building
+====
+
+
+## Running
+====


### PR DESCRIPTION
I've introduced a stubbed readme, an initial pom.xml for maven support, and a blank travis.yml file. The readme stub contains some sections we can fill in to instruct developers and users how to build and run the project. The initial pom contains most of the dependencies needed to build the project and local development environments, but MASON is not being actively maintained in Maven Central, which causes build errors. The travis.yml file can be populated to automatically run tests and builds for the project.